### PR TITLE
make sure plain text products and topics get removed after processing

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -365,7 +365,7 @@ function addNavToggleListener() {
     if (last) {
       let topics, container;
       Array.from(last.children).forEach((i) => {
-        const r = /^Topics\: (.*)$/gmi.exec(i.innerText);
+        const r = /^Topics\: ?(.*)$/gmi.exec(i.innerText);
         if (r && r.length > 0) {
           topics = r[1].split(',');
           container = i;
@@ -398,7 +398,7 @@ function addNavToggleListener() {
       insertInside.classList.add('left');
       let products, container;
       Array.from(last.children).forEach((i) => {
-        const r = /^Products\: (.*)$/gmi.exec(i.innerText);
+        const r = /^Products\: ?(.*)$/gmi.exec(i.innerText);
         if (r && r.length > 0) {
           products = r[1].split(',');
           container = i;


### PR DESCRIPTION
Fix #61 

#62 didn't quite work because the regexp expected a trailing whitespace after `Products:` and `Topics:`. Now it is optional.