### PR TITLE
skip posts with dates in the future

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -232,7 +232,12 @@
           empty: emptyTemplate,
         },
         transformItems(items) {
-          return items.map(item => transformer(item));
+          return items
+            .filter((item) => {
+              // hide articles with future dates
+              return item.date * 1000 < Date.now();
+            })
+            .map((item, index) => transformer(item, index));
         },
       }),
     ]);
@@ -273,10 +278,10 @@
         </div>
       </div>
       `,
-      transformer: (item) => {
+      transformer: (item, index) => {
         item = itemTransformer(item); 
-        if (item.__position === 1) {
-          // use larger hero image
+        if (index === 0) {
+          // use larger hero image on first article
           item.hero = item.hero.replace('?width=256', '?width=2048');
         } 
         return item;

--- a/scripts.js
+++ b/scripts.js
@@ -211,7 +211,6 @@
     emptyTemplate = 'There are no articles yet',
     transformer = itemTransformer,
   }) {
-    // const searchClient = algoliasearch('LPQI0MG7ST', '9bf61456f606d21ddc1723f30500659e');
     const searchClient = algoliasearch('A8PL9E4TZT', '9e59db3654d13f71d79c4fbb4a23cc72');
     const search = instantsearch({
       indexName,
@@ -222,6 +221,9 @@
       instantsearch.widgets.configure({
         hitsPerPage,
         facetFilters,
+        numericFilters: [
+          `date < ${Date.now()/1000}`, // hide articles with future dates
+         ]
       }),
     ]);
     search.addWidgets([
@@ -232,12 +234,7 @@
           empty: emptyTemplate,
         },
         transformItems(items) {
-          return items
-            .filter((item) => {
-              // hide articles with future dates
-              return item.date * 1000 < Date.now();
-            })
-            .map((item, index) => transformer(item, index));
+          return items.map((item, index) => transformer(item, index));
         },
       }),
     ]);


### PR DESCRIPTION
Fix #97 

Test: the date property for [this post](https://no-future--theblog--davidnuescheler.hlx.page/ms/archive/posts/2020/adobe-character-animator-receives-emmy-award-for-technology-and-engineering.html) has been boosted to the near future in the Algolia index, so it should no longer show up on the [homepage](https://no-future--theblog--davidnuescheler.hlx.page).