### PR TITLE
block search engines from crawling POC site

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,5 +1,6 @@
 <link rel="stylesheet" href="/style.css"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="robots" content="noindex, nofollow">
 <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
 
 <script defer src="https://www.stage.adobe.com/etc.clientlibs/globalnav/clientlibs/base/polyfills.js"></script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
From @auniverseaway: Did anyone put in the header tags (and robots.txt) to make sure Google, Baidu, and Bing didn’t start crawling the POC Helix blog site?